### PR TITLE
Fix inline query of `ecs_instance_long_running` control to only check for instances in running state

### DIFF
--- a/controls/ecs.sp
+++ b/controls/ecs.sp
@@ -190,7 +190,7 @@ control "ecs_instance_long_running" {
     from
       alicloud_ecs_instance
     where
-      status in ('Running', 'Pending');
+      status = 'Running';
   EOT
 
   param "ecs_running_instance_age_max_days" {


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked
